### PR TITLE
Add Honeybadger for reporting uncaught exceptions.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -26,3 +26,5 @@ require 'dlss/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
+
+require 'capistrano/honeybadger'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "grape"
 gem 'modsulator'
 gem "bundler"
+gem 'honeybadger', '~> 2.0'
 
 group :test do
   gem "equivalent-xml", '>= 0.6.0'   # For ignoring_attr_values() with arguments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       rack-mount
       virtus (>= 1.0.0)
     hashie (3.4.3)
+    honeybadger (2.6.1)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -156,6 +157,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.0)
   equivalent-xml (>= 0.6.0)
   grape
+  honeybadger (~> 2.0)
   modsulator
   rack-test
   rake

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,15 @@
 require File.dirname(__FILE__) + '/config/boot.rb'
+require 'honeybadger'
 
 use Rack::CommonLogger, LOG
 use Rack::ShowExceptions
+
+# Configure and start Honeybadger
+honeybadger_config = Honeybadger::Config.new(env: ENV['RACK_ENV'])
+Honeybadger.start(honeybadger_config)
+
+# And use Honeybadger's rack middleware
+use Honeybadger::Rack::ErrorNotifier, honeybadger_config
+use Honeybadger::Rack::MetricsReporter, honeybadger_config
+
 run Spreadsheet::ModsulatorAPI

--- a/lib/modsulator_app.rb
+++ b/lib/modsulator_app.rb
@@ -11,12 +11,6 @@ module Spreadsheet
     format :txt
     default_format :txt
 
-    rescue_from :all do |e|
-      LOG.error("Caught an exception: #{e.message}")
-      LOG.error(e.backtrace.join("\n"))
-      error!("Caught an exception: #{e.message}")
-    end
-
     resource :about do
       # Simple ping to see if the application is up
       # GET http://localhost:9292/v1/about


### PR DESCRIPTION
Previously there was a rescue_from :all block in lib/modsulator_app.rb - that block had to be removed in order for uncaught exceptions to be intercepted by Honeybadger. I believe we'll still see exception output in the regular server logs, though.
